### PR TITLE
Some hotfixes in examples to make them work with the latest FVIP

### DIFF
--- a/AXI4/examples/axi4_lite_gpio_destination/axilgpio.sby
+++ b/AXI4/examples/axi4_lite_gpio_destination/axilgpio.sby
@@ -19,6 +19,8 @@ read -sv amba_axi4_definition_of_axi4_lite.sv
 read -sv amba_axi4_atomic_accesses.sv
 read -sv amba_axi4_transaction_structure.sv
 read -sv amba_axi4_transaction_attributes.sv
+read -sv amba_axi4_low_power_interface.sv
+read -sv amba_axi4_low_power_channel.sv
 
 # new checkers
 read -sv amba_axi4_write_response_dependencies.sv
@@ -45,12 +47,13 @@ prep -flatten -top axilgpio
 [files]
 # Packages
 ../../src/amba_axi4_protocol_checker_pkg.sv
+../../src/amba_axi4_low_power_channel.sv
 ../../src/axi4_spec/amba_axi4_single_interface_requirements.sv
 ../../src/axi4_spec/amba_axi4_definition_of_axi4_lite.sv
 ../../src/axi4_spec/amba_axi4_atomic_accesses.sv
 ../../src/axi4_spec/amba_axi4_transaction_structure.sv
 ../../src/axi4_spec/amba_axi4_transaction_attributes.sv
-../../src/axi4_spec/amba_axi4_write_response_dependencies.sv
+../../src/axi4_spec/amba_axi4_low_power_interface.sv
 ../../src/axi4_lib/amba_axi4_write_response_dependencies.sv
 ../../src/axi4_lib/amba_axi4_exclusive_access_source_perspective.sv
 

--- a/AXI4/examples/axi4_lite_gpio_destination/yosyshq_lite_source.sv
+++ b/AXI4/examples/axi4_lite_gpio_destination/yosyshq_lite_source.sv
@@ -35,6 +35,7 @@ bind axilgpio amba_axi4_protocol_checker
 	   MAXWAIT:           16,
 	   VERIFY_AGENT_TYPE: amba_axi4_protocol_checker_pkg::DESTINATION,
 	   PROTOCOL_TYPE:     amba_axi4_protocol_checker_pkg::AXI4LITE,
+	   INTERFACE_REQS:    1,
 	   ENABLE_COVER:      1,
 	   ENABLE_XPROP:      0,
 	   ARM_RECOMMENDED:   1,
@@ -42,7 +43,8 @@ bind axilgpio amba_axi4_protocol_checker
 	   OPTIONAL_WSTRB:    1,
 	   FULL_WR_STRB:      1,
 	   OPTIONAL_RESET:    0,
-	   EXCLUSIVE_ACCESS:  1})) yosyshq_axi4_checker_destination
+	   EXCLUSIVE_ACCESS:  1,
+	   OPTIONAL_LP:       0})) yosyshq_axi4_checker_destination
   (.ACLK(S_AXI_ACLK),
    .ARESETn(S_AXI_ARESETN),
 

--- a/AXI4/examples/axi_crossbar/axi_crossbar.sby
+++ b/AXI4/examples/axi_crossbar/axi_crossbar.sby
@@ -19,6 +19,8 @@ read -sv amba_axi4_atomic_accesses.sv
 read -sv amba_axi4_transaction_structure.sv
 read -sv amba_axi4_transaction_attributes.sv
 read -sv amba_axi4_protocol_checker.sv
+read -sv amba_axi4_low_power_interface.sv
+read -sv amba_axi4_low_power_channel.sv
 
 # new checkers
 read -sv amba_axi4_write_response_dependencies.sv
@@ -54,6 +56,8 @@ prep -flatten -top axi_crossbar
 ../../src/amba_axi4_read_data_channel.sv
 ../../src/amba_axi4_read_address_channel.sv
 ../../src/amba_axi4_protocol_checker.sv
+../../src/amba_axi4_low_power_channel.sv
+
 testbench.sv
 ../../src/amba_axi4_protocol_checker_pkg.sv
 ../../src/axi4_spec/amba_axi4_single_interface_requirements.sv
@@ -61,8 +65,9 @@ testbench.sv
 ../../src/axi4_spec/amba_axi4_atomic_accesses.sv
 ../../src/axi4_spec/amba_axi4_transaction_structure.sv
 ../../src/axi4_spec/amba_axi4_transaction_attributes.sv
-../../src/axi4_lib/amba_axi4_write_response_dependencies.sv
+../../src/axi4_spec/amba_axi4_low_power_interface.sv
 ../../src/axi4_lib/amba_axi4_exclusive_access_source_perspective.sv
+../../src/axi4_lib/amba_axi4_write_response_dependencies.sv
 axi_crossbar_wr.v
 axi_register_rd.v
 arbiter.v

--- a/AXI4/examples/axi_crossbar/testbench.sv
+++ b/AXI4/examples/axi_crossbar/testbench.sv
@@ -32,6 +32,7 @@ bind axi_crossbar amba_axi4_protocol_checker
       MAXWAIT:           20,
       VERIFY_AGENT_TYPE: amba_axi4_protocol_checker_pkg::SOURCE,
       PROTOCOL_TYPE:     amba_axi4_protocol_checker_pkg::AXI4FULL,
+      INTERFACE_REQS:    1,
       ENABLE_COVER:      1,
       ENABLE_XPROP:      0,
       ARM_RECOMMENDED:   1,
@@ -39,7 +40,8 @@ bind axi_crossbar amba_axi4_protocol_checker
       OPTIONAL_WSTRB:    1,
       FULL_WR_STRB:      1,
       OPTIONAL_RESET:    0,
-      EXCLUSIVE_ACCESS:  1})
+      EXCLUSIVE_ACCESS:  1,
+      OPTIONAL_LP:       0})
 source_chk (
 	    .ACLK(clk),
 	    .ARESETn(!rst),
@@ -111,6 +113,7 @@ bind axi_crossbar amba_axi4_protocol_checker
       MAXWAIT:           20,
       VERIFY_AGENT_TYPE: amba_axi4_protocol_checker_pkg::DESTINATION,
       PROTOCOL_TYPE:     amba_axi4_protocol_checker_pkg::AXI4FULL,
+      INTERFACE_REQS:    1,
       ENABLE_COVER:      1,
       ENABLE_XPROP:      0,
       ARM_RECOMMENDED:   0,
@@ -118,7 +121,8 @@ bind axi_crossbar amba_axi4_protocol_checker
       OPTIONAL_WSTRB:    1,
       FULL_WR_STRB:      1,
       OPTIONAL_RESET:    0,
-      EXCLUSIVE_ACCESS:  1})
+      EXCLUSIVE_ACCESS:  1,
+      OPTIONAL_LP:       0})
 dest_check (
 	    .ACLK(clk),
 	    .ARESETn(!rst),

--- a/AXI4/examples/synthesis_test/axi4_full/synthesis_test.sby
+++ b/AXI4/examples/synthesis_test/axi4_full/synthesis_test.sby
@@ -18,6 +18,8 @@ read -sv amba_axi4_definition_of_axi4_lite.sv
 read -sv amba_axi4_atomic_accesses.sv
 read -sv amba_axi4_transaction_structure.sv
 read -sv amba_axi4_transaction_attributes.sv
+read -sv amba_axi4_low_power_interface.sv
+read -sv amba_axi4_low_power_channel.sv
 
 # new checkers
 read -sv amba_axi4_write_response_dependencies.sv
@@ -35,11 +37,13 @@ prep -flatten -top testbench
 top_cell.sv
 testbench.sv
 ../../../src/amba_axi4_protocol_checker_pkg.sv
+../../../src/amba_axi4_low_power_channel.sv
 ../../../src/axi4_spec/amba_axi4_single_interface_requirements.sv
 ../../../src/axi4_spec/amba_axi4_definition_of_axi4_lite.sv
 ../../../src/axi4_spec/amba_axi4_atomic_accesses.sv
 ../../../src/axi4_spec/amba_axi4_transaction_structure.sv
 ../../../src/axi4_spec/amba_axi4_transaction_attributes.sv
+../../../src/axi4_spec/amba_axi4_low_power_interface.sv
 ../../../src/axi4_lib/amba_axi4_write_response_dependencies.sv
 ../../../src/axi4_lib/amba_axi4_exclusive_access_source_perspective.sv
 #../../../src/axi4_lib/exclusive_access_checker.sv

--- a/AXI4/examples/synthesis_test/axi4_full/testbench.sv
+++ b/AXI4/examples/synthesis_test/axi4_full/testbench.sv
@@ -44,7 +44,8 @@ localparam axi4_checker_params_t
 	      OPTIONAL_WSTRB:    1,
 	      FULL_WR_STRB:      1,
 	      OPTIONAL_RESET:    1,
-	      EXCLUSIVE_ACCESS:  1};
+	      EXCLUSIVE_ACCESS:  1,
+	      OPTIONAL_LP:       0};
 bind testbench amba_axi4_protocol_checker #(.cfg(cfg_cons)) assumes_provider (.*);
 
 // Connect a monitor entity
@@ -73,7 +74,8 @@ localparam axi4_checker_params_t
 	     OPTIONAL_WSTRB:    1,
 	     FULL_WR_STRB:      1,
 	     OPTIONAL_RESET:    1,
-	     EXCLUSIVE_ACCESS:  1};
+	     EXCLUSIVE_ACCESS:  1,
+	     OPTIONAL_LP:       0};
 bind testbench amba_axi4_protocol_checker #(.cfg(cfg_mon)) asserts_provider (.*);
 
 // The actual interface
@@ -102,7 +104,8 @@ module testbench
       OPTIONAL_WSTRB:    1,
       FULL_WR_STRB:      1,
       OPTIONAL_RESET:    1,
-      EXCLUSIVE_ACCESS:  1},
+      EXCLUSIVE_ACCESS:  1,
+      OPTIONAL_LP:       0},
     // Read only
     localparam unsigned STRB_WIDTH = cfg.DATA_WIDTH/8)
    (input wire                         ACLK,

--- a/AXI4/examples/synthesis_test/axi4_lite/synthesis_test.sby
+++ b/AXI4/examples/synthesis_test/axi4_lite/synthesis_test.sby
@@ -17,6 +17,8 @@ read -sv amba_axi4_definition_of_axi4_lite.sv
 read -sv amba_axi4_atomic_accesses.sv
 read -sv amba_axi4_transaction_structure.sv
 read -sv amba_axi4_transaction_attributes.sv
+read -sv amba_axi4_low_power_interface.sv
+read -sv amba_axi4_low_power_channel.sv
 
 # new checkers
 read -sv amba_axi4_write_response_dependencies.sv
@@ -33,10 +35,12 @@ prep -flatten -top testbench
 top_cell.sv
 testbench.sv
 ../../../src/amba_axi4_protocol_checker_pkg.sv
+../../../src/amba_axi4_low_power_channel.sv
 ../../../src/axi4_spec/amba_axi4_single_interface_requirements.sv
 ../../../src/axi4_spec/amba_axi4_definition_of_axi4_lite.sv
 ../../../src/axi4_spec/amba_axi4_atomic_accesses.sv
 ../../../src/axi4_spec/amba_axi4_transaction_structure.sv
 ../../../src/axi4_spec/amba_axi4_transaction_attributes.sv
+../../../src/axi4_spec/amba_axi4_low_power_interface.sv
 ../../../src/axi4_lib/amba_axi4_write_response_dependencies.sv
 ../../../src/axi4_lib/amba_axi4_exclusive_access_source_perspective.sv

--- a/AXI4/examples/synthesis_test/axi4_lite/testbench.sv
+++ b/AXI4/examples/synthesis_test/axi4_lite/testbench.sv
@@ -36,6 +36,7 @@ localparam axi4_checker_params_t
 	      MAXWAIT:           16,
 	      VERIFY_AGENT_TYPE: CONSTRAINT,
 	      PROTOCOL_TYPE:     AXI4LITE,
+	      INTERFACE_REQS:    1,
 	      ENABLE_COVER:      1,
 	      ENABLE_XPROP:      1,
 	      ARM_RECOMMENDED:   1,
@@ -43,7 +44,8 @@ localparam axi4_checker_params_t
 	      OPTIONAL_WSTRB:    1,
 	      FULL_WR_STRB:      1,
 	      OPTIONAL_RESET:    1,
-	      EXCLUSIVE_ACCESS:  1};
+	      EXCLUSIVE_ACCESS:  1,
+	      OPTIONAL_LP:       0};
 bind testbench amba_axi4_protocol_checker #(.cfg(cfg_cons)) assumes_provider (.*);
 
 // Connect a monitor entity
@@ -64,6 +66,7 @@ localparam axi4_checker_params_t
 	     MAXWAIT:           16,
 	     VERIFY_AGENT_TYPE: MONITOR,
 	     PROTOCOL_TYPE:     AXI4LITE,
+	     INTERFACE_REQS:    1,
 	     ENABLE_COVER:      1,
 	     ENABLE_XPROP:      1,
 	     ARM_RECOMMENDED:   1,
@@ -71,7 +74,8 @@ localparam axi4_checker_params_t
 	     OPTIONAL_WSTRB:    1,
 	     FULL_WR_STRB:      1,
 	     OPTIONAL_RESET:    1,
-	     EXCLUSIVE_ACCESS:  1};
+	     EXCLUSIVE_ACCESS:  1,
+	     OPTIONAL_LP:       0};
 bind testbench amba_axi4_protocol_checker #(.cfg(cfg_mon)) asserts_provider (.*);
 
 // The actual interface
@@ -92,6 +96,7 @@ module testbench
       MAXWAIT:           16,
       VERIFY_AGENT_TYPE: SOURCE,
       PROTOCOL_TYPE:     AXI4LITE,
+      INTERFACE_REQS:    1,
       ENABLE_COVER:      1,
       ENABLE_XPROP:      1,
       ARM_RECOMMENDED:   1,
@@ -99,7 +104,8 @@ module testbench
       OPTIONAL_WSTRB:    1,
       FULL_WR_STRB:      1,
       OPTIONAL_RESET:    1,
-      EXCLUSIVE_ACCESS:  1},
+      EXCLUSIVE_ACCESS:  1,
+      OPTIONAL_LP:       0},
     // Read only
     localparam unsigned STRB_WIDTH = cfg.DATA_WIDTH/8)
    (input wire                         ACLK,

--- a/AXI4/src/amba_axi4_protocol_checker_pkg.sv
+++ b/AXI4/src/amba_axi4_protocol_checker_pkg.sv
@@ -136,6 +136,8 @@ package amba_axi4_protocol_checker_pkg;
       // To define if the formal IP should verify exclusive transactions,
       // recommended = yes, definetely, if the user IP supports it.
       bit 	   EXCLUSIVE_ACCESS;
+      // Enable support for the optional AXI low-power interface extension
+      bit 	   OPTIONAL_LP;
    } axi4_checker_params_t;
 endpackage // amba_axi4_protocol_checker_pkg
 `endif


### PR DESCRIPTION
I've tried to run the examples and ran into a few issues with the examples not being up to date with the current FVIP.

This fixes some of those issues I've seen but not all. It might be a good idea to add a `make test`-like top-level script to run all examples and check if they produce the expected outputs.